### PR TITLE
Bug Fix: enable foreign key constraints

### DIFF
--- a/src/main/java/model/database/SqliteDatabaseConnectionFactory.java
+++ b/src/main/java/model/database/SqliteDatabaseConnectionFactory.java
@@ -17,7 +17,7 @@ public class SqliteDatabaseConnectionFactory {
   private static void connect() {
     try {
       Class.forName("org.sqlite.JDBC");
-      c = DriverManager.getConnection("jdbc:sqlite:project_management_app.db");
+      c = DriverManager.getConnection("jdbc:sqlite:project_management_app.db?foreign_keys=on");
     } catch (ClassNotFoundException | SQLException e) {
       e.printStackTrace();
       System.exit(1);


### PR DESCRIPTION
### Context
By default, in SQLite the foreign key constraints are disabled, so updates, insertions and deletions violating the constraints are allowed.  This would make the application easier to break. 
References:

- https://sqlite.org/foreignkeys.html
- https://stackoverflow.com/questions/9937713/does-sqlite3-not-support-foreign-key-constraints

### Solution
Whenever a connection is established with the database, the foreign key constraints are enabled. 

Remark that the "PRAGMA" command mentioned in the above links was considered but did not work. 
