### PR TITLE
Bug Fix: MainFrame's TeamList update

### DIFF
--- a/src/main/java/controller/team/TeamListController.java
+++ b/src/main/java/controller/team/TeamListController.java
@@ -69,7 +69,9 @@ public class TeamListController implements PropertyChangeListener {
         || propertyChangeEvent
             .getPropertyName()
             .equals(TeamManager.ChangablePropertyName.CHANGED_TEAM_MANAGER.toString())
-    || propertyChangeEvent.getPropertyName().equals(TeamManager.ChangablePropertyName.CHANGED_TEAM_NAME.toString())) {
+        || propertyChangeEvent
+            .getPropertyName()
+            .equals(TeamManager.ChangablePropertyName.CHANGED_TEAM_NAME.toString())) {
       panel.updateTeams();
     }
   }


### PR DESCRIPTION
I update the listener needed to update the list of teams in the MainFrame when the name/manager of any of them is changed. 