### PR TITLE
Bug Fix: DatePicker

### DIFF
--- a/src/main/java/view/project/single_project/ProjectDetailsPanel.java
+++ b/src/main/java/view/project/single_project/ProjectDetailsPanel.java
@@ -9,7 +9,6 @@ import org.jdatepicker.impl.UtilDateModel;
 import view.UIFactory;
 
 import javax.swing.*;
-import javax.swing.text.DefaultFormatter;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -116,8 +115,8 @@ public class ProjectDetailsPanel extends JPanel {
   private void setDeadlineDate() {
     dateModel.setDate(
         controller.getProjectDeadline().getYear(),
-        controller.getProjectDeadline().getMonthValue() - 1, //deadlineDatePicker counts from 0,
-            // but LocalDate from 1
+        controller.getProjectDeadline().getMonthValue() - 1, // deadlineDatePicker counts from 0,
+        // but LocalDate from 1
         controller.getProjectDeadline().getDayOfMonth());
     dateModel.setSelected(true);
   }
@@ -381,8 +380,8 @@ public class ProjectDetailsPanel extends JPanel {
         LocalDate selectedDate =
             LocalDate.of(
                 deadlineDatePicker.getModel().getYear(),
-                deadlineDatePicker.getModel().getMonth() + 1, //deadlineDatePicker counts from 0,
-                    // but LocalDate from 1
+                deadlineDatePicker.getModel().getMonth() + 1, // deadlineDatePicker counts from 0,
+                // but LocalDate from 1
                 deadlineDatePicker.getModel().getDay());
         String description = descriptionTextArea.getText();
         controller.saveProject(title, assignee, supervisor, selectedDate, description);


### PR DESCRIPTION
I fixed 1 bug related to the date picking functionality: because JDatePicker counts the months from 0 to 11 and LocalDate from 1 to 12, there was an inconsistency between them which cause exceptions if an invalid number was provided/invalid values were saved in the database.

More than that, I revised the layout and provided a DateLabelFormatter for the JDatePickerImpl, so that the calendar is displayed only when the user clicks on the corresponding box, which displayed the currently selected date only by default. 

https://user-images.githubusercontent.com/25320744/103178676-8726fd00-488d-11eb-8639-9e06863f96dc.mp4


