### PR TITLE
LeaveTeam MessageDialog

### DIFF
--- a/src/main/java/controller/team/single_team/TeamSettingsController.java
+++ b/src/main/java/controller/team/single_team/TeamSettingsController.java
@@ -137,8 +137,8 @@ public class TeamSettingsController extends TeamController
   }
   /** Displays a message dialog to inform the user that he/she has left the team. */
   private void affirmLeavingTeam() {
-    JOptionPane.showMessageDialog(frame, AFFIRM_LEAVING_TEAM_MESSAGE, AFFIRM_LEAVING_TEAM_TITLE,
-            JOptionPane.PLAIN_MESSAGE);
+    JOptionPane.showMessageDialog(
+        frame, AFFIRM_LEAVING_TEAM_MESSAGE, AFFIRM_LEAVING_TEAM_TITLE, JOptionPane.PLAIN_MESSAGE);
   }
 
   /**


### PR DESCRIPTION
I replaced the ConfirmDialog with a MessageDialog because no further confirmation is needed from the user after leaving the team.